### PR TITLE
Add Logging for connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ the chain:
 $ php leproxy.php 0.0.0.0:1080 127.1.1.1:1080 127.2.2.2:1080 127.3.3.3:1080
 ```
 
+To keep track of the requests on the proxy you can activate the logging:
+
+```bash
+$ php leproxy.php --log
+```
+
 ## Clients
 
 Once LeProxy is running, you can start using it with pretty much any client

--- a/src/LeProxyServer.php
+++ b/src/LeProxyServer.php
@@ -60,6 +60,10 @@ class LeProxyServer
 
             $http->setAuthArray($auth);
             $socks->setAuthArray($auth);
+
+            if ($this->connector instanceof LoggingConnector) {
+                $this->connector->setAuth($auth);
+            }
         }
 
         return $socket;

--- a/src/LoggingConnector.php
+++ b/src/LoggingConnector.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace LeProxy\LeProxy;
+
+use React\Socket\Connector;
+use React\Promise\Promise;
+use React\Stream\WritableStreamInterface;
+use React\Socket\ConnectorInterface;
+use React\Socket\ConnectionInterface;
+use Clue\React\HttpProxy\ProxyConnector as HttpClient;
+use Clue\React\Socks\Client as SocksClient;
+
+/** @internal */
+class LoggingConnector implements ConnectorInterface
+{
+    private $connector;
+    private $outputStream;
+    private $protocol = 'tcp';
+    private $auth = null;
+
+    public function __construct(ConnectorInterface $connector, WritableStreamInterface $outputStream)
+    {
+        if ($connector instanceof HttpClient) {
+            $this->protocol = 'http';
+        }
+
+        if ($connector instanceof SocksClient) {
+            $this->protocol = 'socks5';
+        }
+
+        $this->connector = $connector;
+        $this->outputStream = $outputStream;
+    }
+
+    public function connect($uri)
+    {
+        $that = $this;
+        $connector = $this->connector;
+        $auth = $this->auth;
+
+        return new Promise(
+            function ($resolve, $reject) use ($connector, $uri, $that, $auth) {
+                $connector->connect($uri)->then(
+                    function (ConnectionInterface $remote) use ($that, $uri, $resolve, $auth) {
+                        $address = str_replace('tcp://', $this->protocol . '://', $remote->getLocalAddress());
+                        $message = 'connected ' . $address . ' to tcp://' . $uri;
+                        if ($auth !== null) {
+                            foreach ($auth as $user => $key) {
+                                $message = 'connected ' . $user . '@' . $address . ' to tcp://' . $uri;
+                            }
+                        }
+
+                        $that->log($message);
+                        $resolve($remote);
+                    }
+                );
+            }
+        );
+    }
+
+    public function log($message)
+    {
+        $this->outputStream->write(date('Y-m-d H:i:s') . ' ' . $message. PHP_EOL);
+    }
+
+    public function setAuth($auth)
+    {
+        $this->auth = $auth;
+    }
+}

--- a/tests/LoggingConnectorTest.php
+++ b/tests/LoggingConnectorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use React\Stream\ThroughStream;
+use React\Promise\Promise;
+use LeProxy\LeProxy\LoggingConnector;
+
+class LoggingConnectorTest extends PHPUnit_Framework_TestCase
+{
+    private $httpConnector;
+    private $socksConnector;
+    private $stream;
+
+    public function setUp()
+    {
+        $connection = $this->getMockBuilder('React\Socket\Connection')->disableOriginalConstructor()->getMock();
+        $connection->method('getLocalAddress')->willReturn('tcp://192.168.1.2');
+
+        $this->httpConnector = $this->getMockBuilder('Clue\React\HttpProxy\ProxyConnector')->disableOriginalConstructor()->getMock();
+        $this->httpConnector
+            ->method('connect')
+            ->willReturn(new Promise(function ($resolve, $reject) use ($connection) {
+                $resolve($connection);
+            }));
+
+        $this->socksConnector = $this->getMockBuilder('Clue\React\Socks\Client')->disableOriginalConstructor()->getMock();
+        $this->socksConnector
+            ->method('connect')
+            ->willReturn(new Promise(function ($resolve, $reject) use ($connection) {
+                $resolve($connection);
+            }));
+
+        $this->stream = new ThroughStream();
+    }
+
+    public function testWithoutAuthWillBeLogged()
+    {
+        $result= '';
+        $this->stream->on('data', function($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $logging = new LoggingConnector($this->httpConnector, $this->stream);
+        $logging->connect('google.com:443');
+
+        $this->assertContains('connected http://192.168.1.2 to tcp://google.com:443', $result);
+    }
+
+    public function testWithAuthWillBeLogged()
+    {
+
+        $result= '';
+        $this->stream->on('data', function($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $logging = new LoggingConnector($this->httpConnector, $this->stream);
+        $logging->setAuth(array('legionth' => 'test'));
+
+        $logging->connect('google.com:443');
+
+        $this->assertContains('connected legionth@http://192.168.1.2 to tcp://google.com:443', $result);
+    }
+
+    public function testSocksProtocolWillBeLogged()
+    {
+        $result= '';
+        $this->stream->on('data', function($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $logging = new LoggingConnector($this->socksConnector, $this->stream);
+        $logging->connect('google.com:443');
+
+        $this->assertContains('connected socks5://192.168.1.2 to tcp://google.com:443', $result);
+    }
+}


### PR DESCRIPTION
This PRs enables logging of the client that connect to LeProxy. This will be automatically started when LeProxy is started.