### PR TITLE
Remove unneeded HTTP server error debugging messages

### DIFF
--- a/src/HttpProxyServer.php
+++ b/src/HttpProxyServer.php
@@ -28,8 +28,6 @@ class HttpProxyServer
         $that = $this;
         $server = new \React\Http\Server(array($this, 'handleRequest'));
         $server->listen($socket);
-
-        $server->on('error', 'printf');
     }
 
     public function setAuthArray(array $auth)


### PR DESCRIPTION
This fixes what previously looked like a bug, when full exception traces have been printed to the console output. This error handling is not actually a bug, but IMO it's a bug to present it as an issue :-)