### PR TITLE
[WIP] Add web proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ http://127.0.0.1:1080/pac
   settings.
   If your client disallows this, simply remove or disable these settings again.
 
+## Web proxy
+
+Once LeProxy is running, you can use the internal web proxy by entering:
+`http://<address>:<port>/web`, so like in the examples before enter:
+`http://127.0.0.1:1080/web`
+
+The web proxy only excepts responses that or not bigger than 2MB. If you want
+to access bigger sites or download a file, you should consider to configure
+your [browser](#clients) to use LeProxy.
+
+> Note that the web proxy is currently under development and several features
+have to be implemented.
+Currently the following features are not supoorted: CSS(style, images etc.), cookies, srcset/images, meta tags(http-equiv) and HTTPS.
+
 ## License
 
 MIT-licensed

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,9 @@
             "src/ConnectorFactory.php",
             "src/HttpProxyServer.php",
             "src/LeProxyServer.php",
+            "src/ProtocolDetector.php",
             "src/NullServer.php",
-            "src/ProtocolDetector.php"
+            "src/HttpClient.php"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
             "src/ConnectorFactory.php",
             "src/HttpProxyServer.php",
             "src/LeProxyServer.php",
-            "src/ProtocolDetector.php",
             "src/NullServer.php",
-            "src/HttpClient.php"
+            "src/ProtocolDetector.php",
+            "src/HttpClient.php",
+            "src/WebProxy.php"
         ]
     }
 }

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -1,0 +1,62 @@
+<?php
+
+use React\Promise\Deferred;
+use React\HttpClient\Response as ClientResponse;
+use React\Http\Response;
+use React\HttpClient\Client as ReactHttpClient;
+use React\Stream\ReadableStreamInterface;
+use Psr\Http\Message\RequestInterface;
+
+/** @internal */
+class HttpClient
+{
+    private $client;
+
+    public function __construct(ReactHttpClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function send(RequestInterface $request)
+    {
+        $headers = array();
+        foreach ($request->getHeaders() as $name => $values) {
+            $headers[$name] = implode(', ', $values);
+        }
+
+        $outgoing = $this->client->request(
+            $request->getMethod(),
+            (string)$request->getUri(),
+            $headers,
+            $request->getProtocolVersion()
+        );
+
+        $deferred = new Deferred(function () use ($outgoing) {
+            $outgoing->close();
+            throw new \RuntimeException('Request cancelled');
+        });
+
+        $outgoing->on('response', function (ClientResponse $response) use ($deferred) {
+            $deferred->resolve(new Response(
+                $response->getCode(),
+                $response->getHeaders(),
+                $response,
+                $response->getVersion(),
+                $response->getReasonPhrase()
+            ));
+        });
+
+        $outgoing->on('error', function (Exception $e) use ($deferred) {
+            $deferred->reject($e);
+        });
+
+        if ($request->getBody() instanceof ReadableStreamInterface) {
+            $request->getBody()->pipe($outgoing);
+        }
+        else {
+            $outgoing->end();
+        }
+
+        return $deferred->promise();
+    }
+}

--- a/src/WebProxy.php
+++ b/src/WebProxy.php
@@ -1,0 +1,125 @@
+<?php
+
+use React\Http\Server;
+use React\Http\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RingCentral\Psr7\Request;
+use React\Stream\ThroughStream;
+
+/** @internal */
+class WebProxy
+{
+    private $server;
+    private $serverAddress;
+
+    public function __construct(HttpClient $client, $serverAddress)
+    {
+        $this->client = $client;
+        $this->serverAddress = $serverAddress;
+    }
+
+    public function handleRequest(RequestInterface $request)
+    {
+        $queryParams = $request->getQueryParams();
+        if ($queryParams !== null && isset($queryParams['url'])) {
+            $urlArray = parse_url($queryParams['url']);
+
+            if (isset($urlArray['path']) !== '/') {
+                $url = urldecode($urlArray['path']);
+            }
+
+            if (strpos($url, 'http://') === false) {
+                $url = 'http://' . $url;
+            }
+
+            if (isset($urlArray['query'])) {
+                $url = $url . '?' . $urlArray['query'];
+            }
+
+            $request = new Request('GET', $url);
+            $request = $request->withRequestTarget($url);
+
+            $serverUrl = $this->serverAddress. '/web?url=';
+
+            $that = $this;
+            return $this->client->send($request)->then(function(ResponseInterface $response) use ($serverUrl, $url, $that) {
+
+                $contentType = '';
+                if ($response->hasHeader('Content-Type')) {
+                    $contentType = $response->getHeaderLine('Content-Type');
+                }
+
+                if (strpos($contentType, 'html') === false) {
+                    return $response;
+                }
+
+                $host = parse_url($url)['host'];
+                if ($response->getStatusCode() === 302) {
+                    $location = $that->replacePathForProxy($serverUrl, $host, $response->getHeaderLine('Location'));
+                    $response = $response->withHeader('Location', $location);
+                    return $response;
+                }
+
+                $stream = new ThroughStream();
+
+                $result = new Response(
+                    $response->getStatusCode(),
+                    $response->getHeaders(),
+                    $stream,
+                    $response->getProtocolVersion(),
+                    $response->getReasonPhrase()
+                );
+
+                $buffer = '';
+                $response->getBody()->on('data', function ($data) use (&$buffer) {
+                    $buffer .= $data;
+                });
+
+                $response->getBody()->on('end', function () use ($serverUrl, $host, $stream, &$buffer, $that) {
+                    $doc = new DOMDocument();
+                    $encoding = mb_detect_encoding($buffer, array('UTF-8', 'ISO-8859-1'));
+                    $buffer = mb_convert_encoding($buffer, 'HTML-ENTITIES', $encoding);
+                    @$doc->loadHTML($buffer, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+                    $xpath = new DOMXPath($doc);
+
+                    foreach($xpath->query("//*[@href]") as $element) {
+                        $path = $element->getAttribute('href');
+                        $element->setAttribute('href', $that->replacePathForProxy($serverUrl, $host, $path));
+                    }
+
+                    $body = $doc->saveHTML();
+                    $stream->emit('data', array($body));
+                    $stream->end();
+                });
+
+                return $result;
+            });
+        }
+
+        $body = '<form>';
+        $body .= '<div align="center" style="margin-top: 15%">';
+        $body .= '<input type="text" name="url" label="Enter a URL e.g. http://youtube.com" style="width: 25%">';
+        $body .= '<input type="submit" value="Execute via LeProxy">';
+        $body .= '</div>';
+        $body .= '</form>';
+
+        return new Response(
+            200,
+            array(
+                'Content-Type' => 'text/html'
+            ),
+            $body
+        );
+    }
+
+    /** @internal */
+    public function replacePathForProxy($baseUrl, $host, $path)
+    {
+        if (parse_url($path, PHP_URL_SCHEME) == '') {
+            $path = $host . $path;
+        }
+
+        return $baseUrl. urlencode($path);
+    }
+}

--- a/tests/FunctionalLeProxyServerTest.php
+++ b/tests/FunctionalLeProxyServerTest.php
@@ -232,4 +232,20 @@ class FunctionalLeProxyServerTest extends PHPUnit_Framework_TestCase
         $this->assertContains("\r\n\r\nHTTP/1.1 200 OK\r\n", $response);
         $this->assertContains("PROXY", $response);
     }
+
+    public function testWeb()
+    {
+        // connect to proxy and send plain request to other host
+        $connector = new Connector($this->loop);
+        $promise = $connector->connect($this->proxy)->then(function (ConnectionInterface $conn) {
+            $conn->write("GET http://127.0.0.1:8084/web HTTP/1.1\r\n\r\n");
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($promise, $this->loop, 0.1);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertContains("<form>", $response);
+    }
 }

--- a/tests/WebProxyTest.php
+++ b/tests/WebProxyTest.php
@@ -1,0 +1,257 @@
+<?php
+
+use RingCentral\Psr7\Request;
+use React\Http\Response;
+use React\Promise\Promise;
+use React\Http\ServerRequest;
+use React\Stream\ThroughStream;
+
+class WebProxyTest extends PHPUnit_Framework_TestCase
+{
+    private $client;
+    private $serverAddress;
+
+    public function setUp()
+    {
+        $this->client = $this->getMockBuilder('\HttpClient')->disableOriginalConstructor()->getMock();
+        $this->serverAddress = '127.0.0.1:1080';
+    }
+
+    public function testWebProxyCall()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web');
+        $this->client->method('send')->with($request)->willReturn(
+            new Promise(function ($resolve, $reject) {
+                $resolve(new Response());
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+        $result = $webProxy->handleRequest($request);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $result);
+    }
+
+    public function testReplaceRelativeLinksWithAbsoluteWebProxyLink()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withQueryParams(array('url' => urlencode('httpbin.org')));
+        $stream = new ThroughStream();
+
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) use ($stream) {
+                $resolve(new Response(
+                    200,
+                    array('Content-Type' => 'text/html'),
+                    $stream
+                ));
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $result = '';
+        $response->getBody()->on('data', function ($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $body = '<html>';
+        $body .= '<body>';
+        $body .= '<a href="/ip">';
+        $body .= '<div> this is no a href="bla"</div>';
+        $body .= '<a href="/link">';
+        $body .= '</body>';
+        $body .= '</html>';
+        $stream->emit('data', array($body));
+        $stream->end();
+
+        $this->assertContains('<a href="127.0.0.1:1080/web?url=httpbin.org%2Fip">', $result);
+    }
+
+    public function testReplaceAbsoulteLinksWithWebProxyLinkgs()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withQueryParams(array('url' => urlencode('httpbin.org')));
+        $stream = new ThroughStream();
+
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) use ($stream) {
+                $resolve(new Response(
+                    200,
+                    array('Content-Type' => 'text/html'),
+                    $stream
+                ));
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $result = '';
+        $response->getBody()->on('data', function ($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $body = '<html>';
+        $body .= '<body>';
+        $body .= '<a href="http://example.com">';
+        $body .= '<div> this is no a href="bla"</div>';
+        $body .= '<a href="/link">';
+        $body .= '</body>';
+        $body .= '</html>';
+        $stream->emit('data', array($body));
+        $stream->end();
+
+        $this->assertContains('<a href="127.0.0.1:1080/web?url=http%3A%2F%2Fexample.com">', $result);
+    }
+
+    public function testAlreadyEncodedLinksWontBeEncodedLinksWontBeEncoded()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F');
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F');
+        $request = $request->withQueryParams(array('url' => 'httpbin.org/redirect-to?url=http%3A%2F%2Fexample.com%2F'));
+        $stream = new ThroughStream();
+
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) use ($stream) {
+                $resolve(new Response(
+                    200,
+                    array('Content-Type' => 'text/html'),
+                    $stream
+                ));
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $result = '';
+        $response->getBody()->on('data', function ($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $body = '<html>';
+        $body .= '<body>';
+        $body .= '<a href="http://example.com?url=http://test.com">';
+        $body .= '<div> this is no a href="bla"</div>';
+        $body .= '<a href="/link">';
+        $body .= '</body>';
+        $body .= '</html>';
+        $stream->emit('data', array($body));
+        $stream->end();
+
+        $this->assertContains('<a href="127.0.0.1:1080/web?url=http%3A%2F%2Fexample.com%3Furl%3Dhttp%3A%2F%2Ftest.com">', $result);
+    }
+
+    public function testDontReplaceHtmlSpecialCharsFromResponse()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withQueryParams(array('url' => urlencode('httpbin.org')));
+        $stream = new ThroughStream();
+
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) use ($stream) {
+                $resolve(new Response(
+                    200,
+                    array('Content-Type' => 'text/html'),
+                    $stream
+                ));
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $result = '';
+        $response->getBody()->on('data', function ($data) use (&$result) {
+            $result .= $data;
+        });
+
+        $body = '<html>';
+        $body .= '<body>';
+        $body .= '&nbsp;';
+        $body .= '</body>';
+        $body .= '</html>';
+        $stream->emit('data', array($body));
+        $stream->end();
+
+        $this->assertContains('&nbsp;', $result);
+    }
+
+    public function testReplaceRedirectLocationWithWebProxyUrl()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withQueryParams(array('url' => urlencode('httpbin.org')));
+
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) {
+                $resolve(new Response(
+                    302,
+                    array(
+                        'Content-Type' => 'text/html',
+                        'Location' => 'http://example.com'
+                    )
+                ));
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $this->assertEquals("127.0.0.1:1080/web?url=http%3A%2F%2Fexample.com", $response->getHeaderLine('Location'));
+    }
+
+    public function testWithoutHtmlContentTypeWontBeAdapted()
+    {
+        $request = new ServerRequest('GET', 'http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withRequestTarget('http://127.0.0.1:1080/web?url=' . urlencode('httpbin.org'));
+        $request = $request->withQueryParams(array('url' => urlencode('httpbin.org')));
+
+        $expected = new Response();
+        $this->client->method('send')->willReturn(
+            new Promise(function ($resolve, $reject) use ($expected) {
+                $resolve($expected);
+            })
+        );
+
+        $webProxy = new WebProxy($this->client, $this->serverAddress);
+
+        $promise = $webProxy->handleRequest($request);
+        $response = null;
+        $promise->then(function ($res) use (&$response) {
+            $response = $res;
+        });
+
+        $this->assertSame($expected, $response);
+    }
+}

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -47,5 +47,12 @@ sleep 1
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8182 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8182 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
+# test webproxy
+
+out=$(curl -v --head --fail http://127.0.0.1:8180/web?url=httpbin.org%2Fredirect-to%3Furl%3Dhttp%253A%252F%252Fexample.com%252F 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(curl -v --head --fail http://127.0.0.1:8180/web?url=http%3A%2F%2Fhttpbin.org%2Fredirect%2F6 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(curl -v --head --fail http://127.0.0.1:8180/web?url=http%3A%2F%2Fhttpbin.org%2Fip 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(curl -v --head --fail http://127.0.0.1:8180/web 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+
 killall php 2>&- 1>&- || true
 echo DONE


### PR DESCRIPTION
This PR adds a web proxy that can be used seperate or additional to the current proxies.

Enter `http://127.0.0.1:1080/web` (respectively your current ip and port) in your web browser. The URL can be entered into the input field in the shown form. The entered URL will be added as query parameter to the request. Example: `http://127.0.0.1:1080/web?url=httbin.org`.
Every link on the requested HTML-Site will be replaced with an absolute link to execute it within the web proxy.

This feature is currently experimental, checkout the Readme for features that are currently not supported via the web proxy.