### PR TITLE
Only forward User-Agent header if present in incoming request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "clue/http-proxy-react": "^1.1",
         "clue/socks-react": "^0.8.2",
         "react/http": "^0.7.1",
-        "react/http-client": "^0.5.1"
+        "react/http-client": "^0.5.2"
     },
     "require-dev": {
         "clue/block-react": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e790f33991eacfabd2bf0bb1aed0047",
+    "content-hash": "948802631a030c6a679dbb5bad5e00e6",
     "packages": [
         {
             "name": "clue/commander",
@@ -493,16 +493,16 @@
         },
         {
             "name": "react/http-client",
-            "version": "v0.5.1",
+            "version": "v0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http-client.git",
-                "reference": "9ef920e9e7dc86d340d30ffc63e1b9abd9bc302d"
+                "reference": "2a62a9cf1d1dde36ecc443a59e57c28afc79e713"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http-client/zipball/9ef920e9e7dc86d340d30ffc63e1b9abd9bc302d",
-                "reference": "9ef920e9e7dc86d340d30ffc63e1b9abd9bc302d",
+                "url": "https://api.github.com/repos/reactphp/http-client/zipball/2a62a9cf1d1dde36ecc443a59e57c28afc79e713",
+                "reference": "2a62a9cf1d1dde36ecc443a59e57c28afc79e713",
                 "shasum": ""
             },
             "require": {
@@ -531,7 +531,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2017-06-18T11:48:50+00:00"
+            "time": "2017-06-27T06:45:28+00:00"
         },
         {
             "name": "react/promise",

--- a/src/HttpProxyServer.php
+++ b/src/HttpProxyServer.php
@@ -113,9 +113,9 @@ class HttpProxyServer
                             ->withoutHeader('Proxy-Authorization')
                             ->withoutHeader('Proxy-Connection');
 
-        $headers = array();
-        foreach ($incoming->getHeaders() as $name => $values) {
-            $headers[$name] = implode(', ', $values);
+        $headers = $incoming->getHeaders();
+        if (!$request->hasHeader('User-Agent')) {
+            $headers['User-Agent'] = array();
         }
 
         $outgoing = $this->client->request(

--- a/tests/FunctionalLeProxyServerTest.php
+++ b/tests/FunctionalLeProxyServerTest.php
@@ -56,6 +56,24 @@ class FunctionalLeProxyServerTest extends PHPUnit_Framework_TestCase
 
         $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
         $this->assertContains("\r\n\r\nGET / HTTP/1.1\r\n", $response);
+        $this->assertNotContains("User-Agent:", $response);
+    }
+
+    public function testPlainGetWithExplicitUserAgent()
+    {
+        // connect to proxy and send absolute target URI
+        $connector = new Connector($this->loop);
+        $promise = $connector->connect($this->proxy)->then(function (ConnectionInterface $conn) {
+            $conn->write("GET http://127.0.0.1:8082/ HTTP/1.1\r\nUser-Agent: custom\r\n\r\n");
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($promise, $this->loop, 0.1);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertContains("\r\n\r\nGET / HTTP/1.1\r\n", $response);
+        $this->assertContains("User-Agent: custom\r\n", $response);
     }
 
     public function testPlainGetInvalidUriReturns502()


### PR DESCRIPTION
This simple PR ensures that we only forward a `User-Agent` header to the upstream server if it is present in the incoming proxy request. We no longer apply a default `User-Agent: React/alpha` here.

Refs https://github.com/reactphp/http-client/pull/100 and https://github.com/reactphp/http-client/pull/101