### PR TITLE
Add --block argument to blacklist destination addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ blacklist these by passing the `--block=<destination>` argument.
 Any number of destination addresses can be given.
 Each destination address can be in the form `host` or `host:port` and `host`
 may contain the `*` wildcard to match anything.
-For example, the following can be used to block access to youtube.com and port
-80 on all hosts (standard plaintext HTTP port):
+Subdomains for each host will automatically be blocked.
+For example, the following can be used to block access to `youtube.com` (and its
+subdomains such as `www.youtube.com`) and port 80 on all hosts (standard
+plaintext HTTP port):
 
 ```bash
 $ php leproxy.php --block=youtube.com --block=*:80

--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ the chain:
 $ php leproxy.php 0.0.0.0:1080 127.1.1.1:1080 127.2.2.2:1080 127.3.3.3:1080
 ```
 
+By default, LeProxy allows connections to every destination address as given in
+each incoming proxy request.
+If you want to block access to certain destination hosts and/or ports, you may
+blacklist these by passing the `--block=<destination>` argument.
+Any number of destination addresses can be given.
+Each destination address can be in the form `host` or `host:port` and `host`
+may contain the `*` wildcard to match anything.
+For example, the following can be used to block access to youtube.com and port
+80 on all hosts (standard plaintext HTTP port):
+
+```bash
+$ php leproxy.php --block=youtube.com --block=*:80
+```
+
+> Note that the block list operates on the destination addresses as given in the
+  incoming proxy request. Some [clients](#clients) use local DNS resolution and
+  do not transmit hostnames, but only the resolved destination IP addresses
+  (particularly common for the SOCKS protocol).
+  Make sure to configure your client to use remote DNS resolution accordingly
+  and/or also block access to relevant IP addresses.
+
 ## Clients
 
 Once LeProxy is running, you can start using it with pretty much any client

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "require": {
         "php": ">=5.4",
         "clue/commander": "^1.2.2",
+        "clue/connection-manager-extra": "^1.0",
         "clue/http-proxy-react": "^1.1",
         "clue/socks-react": "^0.8.2",
         "react/http": "^0.7.2",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.4",
         "clue/commander": "^1.2.2",
-        "clue/connection-manager-extra": "^1.0",
+        "clue/connection-manager-extra": "^1.0.1",
         "clue/http-proxy-react": "^1.1",
         "clue/socks-react": "^0.8.2",
         "react/http": "^0.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3d62741bb3981aad9a2bc544f21a8316",
+    "content-hash": "9fe9dfdd5dabf249d83d22c0f95cea99",
     "packages": [
         {
             "name": "clue/commander",
@@ -56,6 +56,64 @@
                 "router"
             ],
             "time": "2017-06-29T20:17:23+00:00"
+        },
+        {
+            "name": "clue/connection-manager-extra",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-connection-manager-extra.git",
+                "reference": "f35aefc1ef88c150c3fa544b772c5a75b0a1d700"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-connection-manager-extra/zipball/f35aefc1ef88c150c3fa544b772c5a75b0a1d700",
+                "reference": "f35aefc1ef88c150c3fa544b772c5a75b0a1d700",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3.5",
+                "react/promise": "^2.1 || ^1.2.1",
+                "react/promise-timer": "^1.1",
+                "react/socket": "^1.0 || ^0.8 || ^0.7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ConnectionManager\\Extra\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "Extra decorators for creating async TCP/IP connections, built on top of ReactPHP's Socket component",
+            "homepage": "https://github.com/clue/php-connection-manager-extra",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "acl",
+                "delay",
+                "firewall",
+                "network",
+                "random",
+                "reactphp",
+                "reject",
+                "repeat",
+                "retry",
+                "timeout"
+            ],
+            "time": "2017-05-09T18:52:19+00:00"
         },
         {
             "name": "clue/http-proxy-react",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9fe9dfdd5dabf249d83d22c0f95cea99",
+    "content-hash": "9c59df51663ed51335a528c47c5b12da",
     "packages": [
         {
             "name": "clue/commander",
@@ -59,16 +59,16 @@
         },
         {
             "name": "clue/connection-manager-extra",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-connection-manager-extra.git",
-                "reference": "f35aefc1ef88c150c3fa544b772c5a75b0a1d700"
+                "reference": "8b73b8a694311589fd09f34b88a6a9003ceb7e6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-connection-manager-extra/zipball/f35aefc1ef88c150c3fa544b772c5a75b0a1d700",
-                "reference": "f35aefc1ef88c150c3fa544b772c5a75b0a1d700",
+                "url": "https://api.github.com/repos/clue/php-connection-manager-extra/zipball/8b73b8a694311589fd09f34b88a6a9003ceb7e6d",
+                "reference": "8b73b8a694311589fd09f34b88a6a9003ceb7e6d",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "retry",
                 "timeout"
             ],
-            "time": "2017-05-09T18:52:19+00:00"
+            "time": "2017-06-23T10:30:30+00:00"
         },
         {
             "name": "clue/http-proxy-react",

--- a/leproxy.php
+++ b/leproxy.php
@@ -42,6 +42,7 @@ Arguments:
         Any number of destination addresses can be given.
         Each destination address can be in the form `host` or `host:port` and
         `host` may contain the `*` wildcard to match anything.
+        Subdomains for each host will automatically be blocked.
 
     --help, -h
         shows this help and exits

--- a/src/ConnectorFactory.php
+++ b/src/ConnectorFactory.php
@@ -62,6 +62,11 @@ class ConnectorFactory
         $filter = array();
         foreach ($block as $host) {
             $filter[$host] = $reject;
+
+            // also reject all subdomains (*.domain), unless this already matches
+            if (substr($host, 0, 1) !== '*') {
+                $filter['*.' . $host] = $reject;
+            }
         }
 
         // this is a blacklist, so allow all other hosts by default

--- a/tests/ConnectorFactoryTest.php
+++ b/tests/ConnectorFactoryTest.php
@@ -60,4 +60,57 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
 
         ConnectorFactory::createConnectorChain(array('///'), $loop);
     }
+
+    public function testEmptyBlockPassesThrough()
+    {
+        $allow = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $allow->expects($this->once())->method('connect')->with('google.com:80');
+
+        $connector = ConnectorFactory::createBlockingConnector(array(), $allow);
+
+        $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);
+        $connector->connect('google.com:80');
+    }
+
+    public function testBlockDomains()
+    {
+        $allow = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $allow->expects($this->once())->method('connect')->with('github.com:443');
+
+        $connector = ConnectorFactory::createBlockingConnector(array('google.com', 'google.de'), $allow);
+
+        $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);
+
+        $this->assertPromiseRejected($connector->connect('google.com:80'));
+        $this->assertPromiseRejected($connector->connect('tcp://google.com:80'));
+        $this->assertPromiseRejected($connector->connect('tls://google.com:443'));
+
+        $connector->connect('github.com:443');
+    }
+
+    public function testBlockHttpPort()
+    {
+        $allow = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $allow->expects($this->once())->method('connect')->with('google.com:443');
+
+        $connector = ConnectorFactory::createBlockingConnector(array('*:80'), $allow);
+
+        $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);
+        $this->assertPromiseRejected($connector->connect('google.com:80'));
+        $this->assertPromiseRejected($connector->connect('tcp://github.com:80'));
+
+        $connector->connect('google.com:443');
+    }
+
+    private function assertPromiseRejected($input)
+    {
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $input);
+
+        $rejected = false;
+        $input->then(null, function () use (&$rejected) {
+            $rejected= true;
+        });
+
+        $this->assertTrue($rejected);
+    }
 }

--- a/tests/ConnectorFactoryTest.php
+++ b/tests/ConnectorFactoryTest.php
@@ -75,7 +75,7 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
     public function testBlockDomains()
     {
         $allow = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $allow->expects($this->once())->method('connect')->with('github.com:443');
+        $allow->expects($this->once())->method('connect')->with('tls://github.com:443');
 
         $connector = ConnectorFactory::createBlockingConnector(array('google.com', 'google.de'), $allow);
 
@@ -85,21 +85,22 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertPromiseRejected($connector->connect('tcp://google.com:80'));
         $this->assertPromiseRejected($connector->connect('tls://google.com:443'));
 
-        $connector->connect('github.com:443');
+        $connector->connect('tls://github.com:443');
     }
 
     public function testBlockHttpPort()
     {
         $allow = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $allow->expects($this->once())->method('connect')->with('google.com:443');
+        $allow->expects($this->once())->method('connect')->with('tls://google.com:443');
 
         $connector = ConnectorFactory::createBlockingConnector(array('*:80'), $allow);
 
         $this->assertInstanceOf('React\Socket\ConnectorInterface', $connector);
         $this->assertPromiseRejected($connector->connect('google.com:80'));
+        $this->assertPromiseRejected($connector->connect('tcp://google.com:80'));
         $this->assertPromiseRejected($connector->connect('tcp://github.com:80'));
 
-        $connector->connect('google.com:443');
+        $connector->connect('tls://google.com:443');
     }
 
     private function assertPromiseRejected($input)

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -37,6 +37,8 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://youtub
 out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 http://www.google.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://google.de 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 http://www.google.de 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://www.youtube.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 https://www.youtube.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -24,6 +24,23 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://test.i
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://test.invalid/test 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8180 http://test.invalid/test 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 
+# restart LeProxy with hosts and plain HTTP port blocked
+killall php 2>&- 1>&-s || true
+php leproxy.php 127.0.0.1:8180 --block=youtube.com --block=*.google.com --block=*:80 &
+sleep 1
+
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://youtube.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 https://youtube.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://www.google.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 https://www.google.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://youtube.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 http://www.google.com 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://google.de 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 http://www.google.de 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(curl -v --head --silent --fail --proxy socks5h://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+
 # restart LeProxy with authentication required
 killall php 2>&- 1>&-s || true
 php leproxy.php user:pass@127.0.0.1:8180 &


### PR DESCRIPTION
This PR adds a new `--block=<destination>` argument that can be used to blacklist any number of destination addresses.

Builds on top of #20