### PR TITLE
Use direct connections for local hosts when PAC is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ http://127.0.0.1:1080/pac
   establish further connections, as most clients will simply ignore invalid
   settings.
   If your client disallows this, simply remove or disable these settings again.
+  LeProxy's PAC file instructs your client to use LeProxy as an HTTP proxy for
+  all public HTTP requests.
+  This means that hostnames that resolve to IPs from your local network will
+  still use a direct connection without going through a proxy.
 
 ## License
 

--- a/src/HttpProxyServer.php
+++ b/src/HttpProxyServer.php
@@ -210,7 +210,23 @@ class HttpProxyServer
             array(
                 'Content-Type' => 'application/x-ns-proxy-autoconfig',
             ) + $this->headers,
-            'function FindProxyForURL(url, host) { return "PROXY ' . $uri . '"; }' . PHP_EOL
-        );
+            <<<EOF
+function FindProxyForURL(url, host) {
+    if (isPlainHostName(host) ||
+        shExpMatch(host, "*.local") ||
+        shExpMatch(host, "*.localhost") ||
+        isInNet(dnsResolve(host), "10.0.0.0", "255.0.0.0") ||
+        isInNet(dnsResolve(host), "172.16.0.0", "255.240.0.0") ||
+        isInNet(dnsResolve(host), "192.168.0.0", "255.255.0.0") ||
+        isInNet(dnsResolve(host), "127.0.0.0", "255.0.0.0")
+    ) {
+        return "DIRECT";
+    }
+
+    return "PROXY $uri";
+}
+
+EOF
+);
     }
 }


### PR DESCRIPTION
Currently, the PAC file instructs the client to *always* use the proxy for *all* requests. With these changes applied, the PAC file only instructs the client to use the proxy for *all public* requests and no longer for requests to local hosts (such as the IP address of a router in the local network).

Builds on top of #13