### PR TITLE
Compile LeProxy into a single standalone release file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /vendor/
-/leproxy.out.php
+/leproxy-*.php

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+/leproxy.out.php

--- a/README.md
+++ b/README.md
@@ -23,30 +23,31 @@ accepting both common HTTP and SOCKS proxy protocols on a single listening port.
 LeProxy requires only PHP.
 *PHP 7+ is highly recommended*, but it runs on any system that uses PHP 5.4+ or
 HHVM.
-
-If you're already familiar with [Composer](http://getcomposer.org), here's the
-quick install guide.
-Simply download LeProxy and run:
+If you have not installed PHP already, on a recent Ubuntu/Debian system, simply run:
 
 ```bash
-$ composer install --no-dev
+$ sudo apt-get install php7.0-cli
 ```
 
+**LeProxy is in early alpha and has no tagged releases yet**,
+please see [Development](#development) below on how to install this locally.
+
+<!--
+You can simply download the latest `leproxy-{version}.php` file from our
+[releases page](https://github.com/leproxy/leproxy/releases):
+
+[Latest release](https://github.com/leproxy/leproxy/releases/latest)
+
+Downloaded the `leproxy-{version}.php` file?
 You did it!! Really simple, huh?
+-->
 
-Anything unclear? Here's the full step-by-step guide:
-The recommend way to install LeProxy is to clone (or download) this repository
-and use [Composer](http://getcomposer.org) to download its dependencies.
-Therefore you'll need PHP, git and curl installed.
-For example, on a recent Ubuntu system, simply run:
-
-```bash
-$ sudo apt-get install php7.0 php7.0-cli git curl
-$ git clone https://github.com/leproxy/leproxy.git
-$ cd leproxy
-$ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install --no-dev
-```
+> LeProxy is distributed as a PHP single file that contains everything you need
+  to run LeProxy.
+  The below examples assume you have saved this file as `leproxy.php` locally,
+  but you can use any name you want.
+  If you're interested in the more technical details of this file, you may want
+  to check out the [development instructions](#development) below.
 
 ## Usage
 
@@ -163,6 +164,80 @@ http://127.0.0.1:8080/pac
   all public HTTP requests.
   This means that hostnames that resolve to IPs from your local network will
   still use a direct connection without going through a proxy.
+
+## Development
+
+LeProxy is an open-source project and encourages everybody to participate in its
+development.
+
+You're interested in checking out how LeProxy works under the hood and/or want
+to contribute to the development of LeProxy?
+Then this section is for you!
+
+The recommended way to install LeProxy is to clone (or download) this repository
+and use [Composer](http://getcomposer.org) to download its dependencies.
+Therefore you'll need PHP, git and curl installed.
+For example, on a recent Ubuntu/debian system, simply run:
+
+```bash
+$ sudo apt-get install php7.0-cli git curl
+$ git clone https://github.com/leproxy/leproxy.git
+$ cd leproxy
+$ curl -s https://getcomposer.org/installer | php
+$ sudo mv composer.phar /usr/local/bin/composer
+$ composer install
+```
+
+That's it already!
+You should now be able to run the development version of LeProxy simply by
+running the `leproxy.php` file like this:
+
+```bash
+$ php leproxy.php
+```
+
+See also [usage](#usage) for more details.
+
+LeProxy uses a sophisticated test suite for functional tests and integration
+tests.
+To run the test suite, go to the project root and run:
+
+```bash
+$ php vendor/bin/phpunit
+```
+
+If you want to distribute LeProxy as a single standalone release file, you may
+compile the project into a single file like this:
+
+```bash
+$ php compile.php
+```
+
+> Note that compiling will temporarily uninstall all development dependencies
+  for distribution and then re-install the complete set of dependencies.
+  This should only take a second or two if you've previously installed its
+  dependencies already.
+  The compile script optionally accepts an output file name or will otherwise
+  try to look up the last release tag, such as `leproxy-v1.0.0.php`.
+
+In addition to the above test suite, LeProxy uses a simple bash/curl-based
+acceptance test setup which can also be used to check the resulting release
+file:
+
+```bash
+$ ./tests/acceptance.sh
+```
+
+> Note that the acceptance tests will try to locate a `leproxy*.php` file in
+  the project directory to run the tests against. You may optionally supply the
+  output file name to test against.
+
+Made some changes to your local development version?
+
+Make sure to let the world know! :shipit:
+We welcome PRs and would love to hear from you!
+
+Happy hacking!
 
 ## License
 

--- a/compile.php
+++ b/compile.php
@@ -1,0 +1,15 @@
+<?php
+
+system('composer install --no-dev --classmap-authoritative');
+$files = require __DIR__ . '/vendor/composer/autoload_classmap.php';
+system('composer install');
+
+//system('cat leproxy.php > leproxy.out.php');
+system('egrep -v "^require " leproxy.php > leproxy.out.php');
+
+foreach ($files as $file) {
+    $file = substr($file, strlen(__DIR__) + 1);
+    //system('cat ' . escapeshellarg($file) . ' >> leproxy.out.php');
+    //system('grep -v "<?php" ' . escapeshellarg($file) . ' >> leproxy.out.php');
+    system('(echo "# ' . $file . '"; grep -v "<?php" ' . escapeshellarg($file) . ') >> leproxy.out.php');
+}

--- a/compile.php
+++ b/compile.php
@@ -1,15 +1,45 @@
 <?php
 
+$out = 'leproxy.out.php';
+
 system('composer install --no-dev --classmap-authoritative');
-$files = require __DIR__ . '/vendor/composer/autoload_classmap.php';
+$classes = require __DIR__ . '/vendor/composer/autoload_classmap.php';
+$includes = require __DIR__ . '/vendor/composer/autoload_files.php';
 system('composer install');
 
-//system('cat leproxy.php > leproxy.out.php');
-system('egrep -v "^require " leproxy.php > leproxy.out.php');
+echo 'Loading ' . count($classes) . ' classes to determine load order...';
+
+// register autoloader which remembers load order
+$ordered = array();
+spl_autoload_register(function ($name) use ($classes, &$ordered) {
+    require $classes[$name];
+    $ordered[$name] = $classes[$name];
+});
+
+// use actual include file instead of include wrapper
+foreach ($includes as $i => $path) {
+    $includes[$i] = str_replace('_include.php', '.php', $path);
+
+    require $path;
+}
+
+// load each class (and its superclasses once) into memory
+foreach ($classes as $class => $path) {
+    class_exists($class, true);
+}
+
+echo ' DONE' . PHP_EOL;
+
+// resulting list of all includes and ordered class list
+$files = array_merge($includes, $ordered);
+echo 'Concatenating ' . count($files) . ' files into ' . $out . '...';
+system('head -n2 leproxy.php > ' . escapeshellarg($out));
 
 foreach ($files as $file) {
     $file = substr($file, strlen(__DIR__) + 1);
-    //system('cat ' . escapeshellarg($file) . ' >> leproxy.out.php');
-    //system('grep -v "<?php" ' . escapeshellarg($file) . ' >> leproxy.out.php');
-    system('(echo "# ' . $file . '"; grep -v "<?php" ' . escapeshellarg($file) . ') >> leproxy.out.php');
+    system('(echo "# ' . $file . '"; grep -v "<?php" ' . escapeshellarg($file) . ') >> ' . escapeshellarg($out));
 }
+
+$file = 'leproxy.php';
+system('(echo "# ' . $file . '"; egrep -v "^<\?php|^require " ' . escapeshellarg($file) . ') >> ' . escapeshellarg($out));
+echo ' DONE' . PHP_EOL;

--- a/compile.php
+++ b/compile.php
@@ -46,12 +46,23 @@ echo ' DONE' . PHP_EOL;
 
 echo 'Optimizing resulting file...';
 $small = '';
-foreach (token_get_all(file_get_contents($out)) as $token) {
+$all = token_get_all(file_get_contents($out));
+foreach ($all as $i => $token) {
     if (is_array($token) && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)) {
-        continue;
+        unset($all[$i]);
     }
+}
+$all = array_values($all);
+foreach ($all as $i => $token) {
     if (is_array($token) && $token[0] === T_WHITESPACE) {
-        $token = strpos($token[1], "\n") !== false ? "\n" : ' ';
+        if (strpos($token[1], "\n") !== false) {
+            $token = substr($small, -1) !== "\n" ? "\n" : '';
+        } else {
+            $last = substr($small, -1);
+            $next = isset($all[$i + 1]) ? substr(is_array($all[$i + 1]) ? $all[$i + 1][1] : $all[$i + 1], 0, 1) : ' ';
+
+            $token = (strpos('()[]{}<>;=+-*/%&|,.:?!@\'"' . PHP_EOL, $last) !== false || strpos('()[]{}<>;=+-*/%&|,.:?!@\'"' . '$', $next) !== false) ? '' : ' ';
+        }
     }
 
     $small .= isset($token[1]) ? $token[1] : $token;

--- a/compile.php
+++ b/compile.php
@@ -43,3 +43,18 @@ foreach ($files as $file) {
 $file = 'leproxy.php';
 system('(echo "# ' . $file . '"; egrep -v "^<\?php|^require " ' . escapeshellarg($file) . ') >> ' . escapeshellarg($out));
 echo ' DONE' . PHP_EOL;
+
+echo 'Optimizing resulting file...';
+$small = '';
+foreach (token_get_all(file_get_contents($out)) as $token) {
+    if (is_array($token) && ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT)) {
+        continue;
+    }
+    if (is_array($token) && $token[0] === T_WHITESPACE) {
+        $token = strpos($token[1], "\n") !== false ? "\n" : ' ';
+    }
+
+    $small .= isset($token[1]) ? $token[1] : $token;
+}
+file_put_contents($out, $small);
+echo ' DONE' . PHP_EOL;

--- a/compile.php
+++ b/compile.php
@@ -42,6 +42,7 @@ foreach ($files as $file) {
 
 $file = 'leproxy.php';
 system('(echo "# ' . $file . '"; egrep -v "^<\?php|^require " ' . escapeshellarg($file) . ') >> ' . escapeshellarg($out));
+chmod($out, 0755);
 echo ' DONE' . PHP_EOL;
 
 echo 'Optimizing resulting file...';

--- a/compile.php
+++ b/compile.php
@@ -1,6 +1,7 @@
 <?php
 
-$out = 'leproxy.out.php';
+// use first argument as output file or use "leproxy-{version}.php"
+$out = isset($argv[1]) ? $argv[1] : ('leproxy-' . exec('git describe --always --dirty || echo dev') . '.php');
 
 system('composer install --no-dev --classmap-authoritative');
 $classes = require __DIR__ . '/vendor/composer/autoload_classmap.php';

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-bin=$(test -f leproxy.out.php && echo leproxy.out.php || echo leproxy.php)
+# test against first argument or search first file matching "leproxy*.php"
+bin=${1:-$(ls -b leproxy*.php | head -n1 || echo leproxy.php)}
 echo "Testing $bin"
 
 # test command line arguments

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
-# test command line arguments
-out=$(php leproxy.php --help) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php -h) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php --unknown 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
-out=$(php leproxy.php --unknown 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php invalid 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php 8080 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php user:pass@[::] --allow-unprotected 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php --proxy= 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
-out=$(php leproxy.php --proxy=tcp://host/ 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+bin=$(test -f leproxy.out.php && echo leproxy.out.php || echo leproxy.php)
+echo "Testing $bin"
 
-killall php 2>&- 1>&-s || true
-php leproxy.php 127.0.0.1:8180 &
+# test command line arguments
+out=$(php $bin --help) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin -h) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin --unknown 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
+out=$(php $bin --unknown 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin invalid 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin 8080 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin user:pass@[::] --allow-unprotected 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin --proxy= 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+out=$(php $bin --proxy=tcp://host/ 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
+
+killall php 2>&- 1>&- || true
+php $bin 127.0.0.1:8180 &
 sleep 2
 
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
@@ -30,8 +33,8 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://test.
 out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8180 http://test.invalid/test 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 
 # restart LeProxy on IPv6 address
-killall php 2>&- 1>&-s || true
-php leproxy.php [::]:8180 &
+killall php 2>&- 1>&- || true
+php $bin [::]:8180 &
 sleep 2
 
 out=$(curl -v --head --silent --fail --proxy http://[::1]:8180 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
@@ -42,8 +45,8 @@ out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8180 http://react
 [ -n "$TRAVIS" ] || out=$(curl -v --head --silent --fail --proxy socks5://[::1]:8180 http://[::1]:8180/pac 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
 # restart LeProxy with authentication required
-killall php 2>&- 1>&-s || true
-php leproxy.php user:pass@127.0.0.1:8180 &
+killall php 2>&- 1>&- || true
+php $bin user:pass@127.0.0.1:8180 &
 sleep 2
 
 # authentication should work
@@ -55,7 +58,7 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://reactp
 out=$(curl -v --head --silent --fail --proxy socks5://127.0.0.1:8180 http://reactphp.org 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 
 # start another LeProxy instance for HTTP proxy chaining / nesting
-php leproxy.php 127.0.0.1:8181 --proxy=http://user:pass@127.0.0.1:8180 &
+php $bin 127.0.0.1:8181 --proxy=http://user:pass@127.0.0.1:8180 &
 sleep 2
 
 # client does not need authentication because first chain passes to next via HTTP
@@ -63,7 +66,7 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8181 http://reactp
 out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8181 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
 # start another LeProxy instance for SOCKS proxy chaining / nesting
-php leproxy.php 127.0.0.1:8182 --proxy=socks://user:pass@127.0.0.1:8180 &
+php $bin 127.0.0.1:8182 --proxy=socks://user:pass@127.0.0.1:8180 &
 sleep 2
 
 # client does not need authentication because first chain passes to next via SOCKS


### PR DESCRIPTION
Using the standalone release file is now the recommended way to install LeProxy.

The release version will be attached to the release that is due soon. In the meantime, the README contains instructions on how to generate a standalone release file yourself.

The resulting release file is currently only around 300 KB in size :shipit: 