### PR TITLE
Log all connection attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ the chain:
 $ php leproxy.php --proxy=127.1.1.1:8080 --proxy=127.2.2.2:8080 --proxy=127.3.3.3:8080
 ```
 
+By default, LeProxy prints a log message for every connection attempt to the
+console output (STDOUT) for debugging and analysis purposes.
+For privacy reasons, it does not persist (store) these log messages on its own.
+If you do not want LeProxy to log anything, you may also pass the `--no-log`
+flag.
+If you want to persist the log to a log file, you may use standard operating
+system facilities such as `tee` to redirect the output to a file:
+
+```bash
+$ php leproxy.php | tee -a leproxy.log
+```
+
 ## Clients
 
 Once LeProxy is running, you can start using it with pretty much any client

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4",
         "clue/commander": "^1.2.2",
         "clue/http-proxy-react": "^1.1",
-        "clue/socks-react": "^0.8.3",
+        "clue/socks-react": "^0.8.4",
         "react/http": "^0.7.2",
         "react/http-client": "^0.5.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b58ced23da83f401dd974ba232ec245a",
+    "content-hash": "c027d283957a060df0c98e4e8b2b74ba",
     "packages": [
         {
             "name": "clue/commander",
@@ -111,16 +111,16 @@
         },
         {
             "name": "clue/socks-react",
-            "version": "v0.8.3",
+            "version": "v0.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-socks-react.git",
-                "reference": "4442bcfbe019721f17f652ee257e2e8539c764af"
+                "reference": "7a6eea83478d291100003584755be9d2a877ed24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-socks-react/zipball/4442bcfbe019721f17f652ee257e2e8539c764af",
-                "reference": "4442bcfbe019721f17f652ee257e2e8539c764af",
+                "url": "https://api.github.com/repos/clue/php-socks-react/zipball/7a6eea83478d291100003584755be9d2a877ed24",
+                "reference": "7a6eea83478d291100003584755be9d2a877ed24",
                 "shasum": ""
             },
             "require": {
@@ -162,7 +162,7 @@
                 "socks server",
                 "tcp tunnel"
             ],
-            "time": "2017-07-18T10:44:17+00:00"
+            "time": "2017-07-27T07:44:09+00:00"
         },
         {
             "name": "evenement/evenement",

--- a/leproxy.php
+++ b/leproxy.php
@@ -136,7 +136,7 @@ $connector = ConnectorFactory::createConnectorChain($args['proxy'], $loop);
 
 // log all connection attempts to STDOUT (unless `--no-log` has been given)
 if (!isset($args['no-log'])) {
-    $connector = new LoggingConnector($connector);
+    $connector = new LoggingConnector($connector, new Logger());
 }
 
 // create proxy server and start listening on given address

--- a/leproxy.php
+++ b/leproxy.php
@@ -38,7 +38,7 @@ $commander->add('-h | --help', function () {
     exit('LeProxy HTTP/SOCKS proxy
 
 Usage:
-    $ php leproxy.php [<listenAddress>] [--allow-unprotected] [--proxy=<upstreamProxy>...]
+    $ php leproxy.php [<listenAddress>] [--allow-unprotected] [--proxy=<upstreamProxy>...] [--no-log]
     $ php leproxy.php --version
     $ php leproxy.php --help
 
@@ -70,6 +70,10 @@ Arguments:
         and password, host and port. Default scheme is `http://`, default port
         is `8080` for all schemes.
 
+    --no-log
+        By default, LeProxy logs all connection attempts to STDOUT for
+        debugging purposes. This can be avoided by passing this argument.
+
     --version
         Prints the current version of LeProxy and exits.
 
@@ -91,7 +95,7 @@ Examples:
         an upstream proxy server that requires authentication.
 ');
 });
-$commander->add('[--allow-unprotected] [--proxy=<upstreamProxy>...] [<listen>]', function ($args) {
+$commander->add('[--allow-unprotected] [--proxy=<upstreamProxy>...] [--no-log] [<listen>]', function ($args) {
     // validate all upstream proxy URIs if given
     if (isset($args['proxy'])) {
         foreach ($args['proxy'] as &$uri) {
@@ -130,8 +134,10 @@ $loop = Factory::create();
 // set next proxy server chain -> p1 -> p2 -> p3 -> destination
 $connector = ConnectorFactory::createConnectorChain($args['proxy'], $loop);
 
-// log all connection attempts to STDOUT
-$connector = new LoggingConnector($connector);
+// log all connection attempts to STDOUT (unless `--no-log` has been given)
+if (!isset($args['no-log'])) {
+    $connector = new LoggingConnector($connector);
+}
 
 // create proxy server and start listening on given address
 $proxy = new LeProxyServer($loop, $connector);

--- a/leproxy.php
+++ b/leproxy.php
@@ -130,6 +130,9 @@ $loop = Factory::create();
 // set next proxy server chain -> p1 -> p2 -> p3 -> destination
 $connector = ConnectorFactory::createConnectorChain($args['proxy'], $loop);
 
+// log all connection attempts to STDOUT
+$connector = new LoggingConnector($connector);
+
 // create proxy server and start listening on given address
 $proxy = new LeProxyServer($loop, $connector);
 try {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace LeProxy\LeProxy;
+
+/**
+ * Domain specific logger, formats and writes out log messages to STDOUT
+ */
+class Logger
+{
+    /**
+     * Logs a successful connection attempt
+     *
+     * @param ?string $source      client source address
+     * @param ?string $destination target destination host or IP
+     * @param ?string $remote      actual remote address may differ from destination address (if known)
+     * @return void
+     */
+    public function logConnection($source, $destination, $remote)
+    {
+        $destination = $this->destination($destination);
+
+        // append actual remote address (IP) to destination if not the same
+        if ($remote !== null) {
+            // only consider host and port from remote address
+            $remote = $this->destination($remote);
+
+            // append actual remote address (IP) only if not the same as destination
+            if ($remote !== $destination) {
+                $destination .= ' (' . $remote . ')';
+            }
+        }
+
+        $this->log($this->source($source) . ' connected to ' . $destination);
+    }
+
+    /**
+     * Logs an unsuccessful connection attempt
+     *
+     * @param ?string $source      client source destination
+     * @param ?string $destination target destination host or IP
+     * @param ?string $reason      rejection/fail reason
+     * @return void
+     */
+    public function logFailConnection($source, $destination, $reason)
+    {
+        $this->log($this->source($source) . ' failed to connect to ' . $this->destination($destination) . ' (' . $reason . ')');
+    }
+
+    /**
+     * Formats the given sources address for logging as `scheme://[user@]ip`
+     *
+     * Removes password and port etc. from URI.
+     *
+     * @param ?string $source
+     * @return string
+     */
+    private function source($source)
+    {
+        $parts = parse_url($source);
+        if (isset($parts['scheme'], $parts['host'])) {
+            $source = $parts['scheme'] . '://';
+            if (isset($parts['user'])) {
+                $source .= $parts['user'] . '@';
+            }
+            $source .= $parts['host'];
+        } else {
+            $source = '???';
+        }
+
+        return $source;
+    }
+
+    /**
+     * Formats the given destination address for logging as `ip:port`
+     *
+     * Removes scheme and query parameter etc. from URI.
+     *
+     * @param string $destination
+     * @return string
+     */
+    private function destination($destination)
+    {
+        $parts = parse_url((strpos($destination, '://') === false ? 'tcp://' : '') . $destination);
+        if ($parts && isset($parts['host'], $parts['port'])) {
+            $destination = $parts['host'] . ':' . $parts['port'];
+        }
+
+        return $destination;
+    }
+
+    /**
+     * Writes the given log message to STDOUT with the current datetime
+     *
+     * @param string $message
+     * @return void
+     */
+    private function log($message)
+    {
+        $time = explode(' ', microtime(false));
+        echo date('Y-m-d H:i:s.', $time[1]) . sprintf('%03d ', $time[0] * 1000) . $message . PHP_EOL;
+    }
+}

--- a/src/LoggingConnector.php
+++ b/src/LoggingConnector.php
@@ -14,67 +14,35 @@ use React\Socket\ConnectionInterface;
 class LoggingConnector implements ConnectorInterface
 {
     private $connector;
+    private $logger;
 
-    public function __construct(ConnectorInterface $connector)
+    public function __construct(ConnectorInterface $connector, Logger $logger)
     {
         $this->connector = $connector;
+        $this->logger = $logger;
     }
 
     public function connect($uri)
     {
-        // format destination as `host:port` (remove scheme and any arguments)
+        // parse source address from URI ?source=X parameter
         $parts = parse_url(((strpos($uri, '://') === false) ? 'tcp://' : '') . $uri);
-        $destination = isset($parts['host'], $parts['port']) ? ($parts['host'] . ':' . $parts['port']) : '???';
-
         $args = array();
         if (isset($parts['query'])) {
             parse_str($parts['query'], $args);
         }
-
-        // format source as `scheme://[user@]ip` (remove password and port)
-        $parts = isset($args['source']) ? parse_url($args['source']) : array();
-        if (isset($parts['scheme'], $parts['host'])) {
-            $source = $parts['scheme'] . '://';
-            if (isset($parts['user'])) {
-                $source .= $parts['user'] . '@';
-            }
-            $source .= $parts['host'];
-        } else {
-            $source = '???';
-        }
+        $source = isset($args['source']) ? $args['source'] : null;
 
         return $this->connector->connect($uri)->then(
-            function (ConnectionInterface $connection) use ($source, $destination) {
-                // append actual remote address (IP) to destination if not the same
-                $remote = $connection->getRemoteAddress();
-                if ($remote !== null) {
-                    // only consider host and port from remote address
-                    $parts = parse_url((strpos($remote, '://') === false ? 'tcp://' : '') . $remote);
-                    if ($parts && isset($parts['host'], $parts['port'])) {
-                        $remote = $parts['host'] . ':' . $parts['port'];
-                    }
-
-                    // append actual remote address (IP) only if not the same as destination
-                    if ($remote !== $destination) {
-                        $destination .= ' (' . $remote . ')';
-                    }
-                }
-
-                $this->log($source . ' connected to ' . $destination);
+            function (ConnectionInterface $connection) use ($source, $uri) {
+                $this->logger->logConnection($source, $uri, $connection->getRemoteAddress());
 
                 return $connection;
             },
-            function (\Exception $e) use ($source, $destination) {
-                $this->log($source . ' failed to connect to ' . $destination . ' (' . $e->getMessage() . ')');
+            function (\Exception $e) use ($source, $uri) {
+                $this->logger->logFailConnection($source, $uri, $e->getMessage());
 
                 throw $e;
             }
         );
-    }
-
-    private function log($message)
-    {
-        $time = explode(' ', microtime(false));
-        echo date('Y-m-d H:i:s.', $time[1]) . sprintf('%03d ', $time[0] * 1000) . $message . PHP_EOL;
     }
 }

--- a/src/LoggingConnector.php
+++ b/src/LoggingConnector.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace LeProxy\LeProxy;
+
+use React\Socket\ConnectorInterface;
+use React\Socket\ConnectionInterface;
+
+/**
+ * Connector decorator which logs the connection attempt
+ *
+ * Parses the source and destination address from the URI for each connection
+ * attempt, forwards the URI to the actual connector and writes a log to STDOUT.
+ */
+class LoggingConnector implements ConnectorInterface
+{
+    private $connector;
+
+    public function __construct(ConnectorInterface $connector)
+    {
+        $this->connector = $connector;
+    }
+
+    public function connect($uri)
+    {
+        // format destination as `host:port` (remove scheme and any arguments)
+        $parts = parse_url(((strpos($uri, '://') === false) ? 'tcp://' : '') . $uri);
+        $destination = isset($parts['host'], $parts['port']) ? ($parts['host'] . ':' . $parts['port']) : '???';
+
+        $args = array();
+        if (isset($parts['query'])) {
+            parse_str($parts['query'], $args);
+        }
+
+        // format source as `scheme://[user@]ip` (remove password and port)
+        $parts = isset($args['source']) ? parse_url($args['source']) : array();
+        if (isset($parts['scheme'], $parts['host'])) {
+            $source = $parts['scheme'] . '://';
+            if (isset($parts['user'])) {
+                $source .= $parts['user'] . '@';
+            }
+            $source .= $parts['host'];
+        } else {
+            $source = '???';
+        }
+
+        return $this->connector->connect($uri)->then(
+            function (ConnectionInterface $connection) use ($source, $destination) {
+                // append actual remote address (IP) to destination if not the same
+                $remote = $connection->getRemoteAddress();
+                if ($remote !== null) {
+                    // only consider host and port from remote address
+                    $parts = parse_url((strpos($remote, '://') === false ? 'tcp://' : '') . $remote);
+                    if ($parts && isset($parts['host'], $parts['port'])) {
+                        $remote = $parts['host'] . ':' . $parts['port'];
+                    }
+
+                    // append actual remote address (IP) only if not the same as destination
+                    if ($remote !== $destination) {
+                        $destination .= ' (' . $remote . ')';
+                    }
+                }
+
+                $this->log($source . ' connected to ' . $destination);
+
+                return $connection;
+            },
+            function (\Exception $e) use ($source, $destination) {
+                $this->log($source . ' failed to connect to ' . $destination . ' (' . $e->getMessage() . ')');
+
+                throw $e;
+            }
+        );
+    }
+
+    private function log($message)
+    {
+        $time = explode(' ', microtime(false));
+        echo date('Y-m-d H:i:s.', $time[1]) . sprintf('%03d ', $time[0] * 1000) . $message . PHP_EOL;
+    }
+}

--- a/src/SourceConnector.php
+++ b/src/SourceConnector.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace LeProxy\LeProxy;
+
+use React\Socket\ConnectorInterface;
+
+/**
+ * Connector decorator to simply append the given source address as an URI query parameter
+ */
+class SourceConnector implements ConnectorInterface
+{
+    private $connector;
+    private $source;
+
+    public function __construct(ConnectorInterface $connector, $source)
+    {
+        $this->connector = $connector;
+        $this->source = $source;
+    }
+
+    public function connect($uri)
+    {
+        $uri .= (strpos($uri, '?') === false ? '?' : '&') . 'source=' . rawurlencode($this->source);
+
+        return $this->connector->connect($uri);
+    }
+}

--- a/tests/FunctionalLeProxyServerTest.php
+++ b/tests/FunctionalLeProxyServerTest.php
@@ -218,6 +218,58 @@ class FunctionalLeProxyServerTest extends PHPUnit_Framework_TestCase
         $this->assertContains("\r\n\r\nUnable to connect:", $response);
     }
 
+    public function testConnectGetWithValidAuth()
+    {
+        $this->socketProxy->close();
+        $proxy = new LeProxyServer($this->loop);
+        $this->socketProxy = $proxy->listen('user:pass@127.0.0.1:8084', false);
+        $this->proxy = $this->socketProxy->getAddress();
+
+        // connect to proxy and send CONNECT requets and then normal request
+        $connector = new Connector($this->loop);
+        $promise = $connector->connect($this->proxy)->then(function (ConnectionInterface $conn) {
+            $conn->write("CONNECT 127.0.0.1:8082 HTTP/1.1\r\nProxy-Authorization: Basic dXNlcjpwYXNz\r\n\r\n");
+
+            $conn->once('data', function () use ($conn) {
+                $conn->write("GET / HTTP/1.1\r\n\r\n");
+            });
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($promise, $this->loop, 0.2);
+
+        $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $response);
+        $this->assertContains("Server: LeProxy\r\n", $response);
+        $this->assertContains("\r\n\r\nHTTP/1.1 200 OK\r\n", $response);
+        $this->assertContains("\r\n\r\nGET / HTTP/1.1\r\n", $response);
+    }
+
+    public function testConnectGetWithInvalidAuthFails()
+    {
+        $this->socketProxy->close();
+        $proxy = new LeProxyServer($this->loop);
+        $this->socketProxy = $proxy->listen('user:pass@127.0.0.1:8084', false);
+        $this->proxy = $this->socketProxy->getAddress();
+
+        // connect to proxy and send CONNECT requets and then normal request
+        $connector = new Connector($this->loop);
+        $promise = $connector->connect($this->proxy)->then(function (ConnectionInterface $conn) {
+            $conn->write("CONNECT 127.0.0.1:8082 HTTP/1.1\r\n\r\n");
+
+            $conn->once('data', function () use ($conn) {
+                $conn->write("GET / HTTP/1.1\r\n\r\n");
+            });
+
+            return Stream\buffer($conn);
+        });
+
+        $response = Block\await($promise, $this->loop, 0.2);
+
+        $this->assertStringStartsWith("HTTP/1.1 407 Proxy Authentication Required\r\n", $response);
+        $this->assertContains("Server: LeProxy\r\n", $response);
+    }
+
     public function testPacDirect()
     {
         // connect to proxy and send direct request

--- a/tests/HttpProxyServerTest.php
+++ b/tests/HttpProxyServerTest.php
@@ -4,6 +4,7 @@ use LeProxy\LeProxy\HttpProxyServer;
 use React\Http\ServerRequest;
 use React\Http\HttpBodyStream;
 use React\Stream\ThroughStream;
+use React\Promise\Promise;
 
 class HttpProxyServerTest extends PHPUnit_Framework_TestCase
 {
@@ -110,6 +111,46 @@ class HttpProxyServerTest extends PHPUnit_Framework_TestCase
         $response = $server->handleRequest($request);
 
         $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    public function testRequestConnectCallsConnector()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $socket = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+
+        $promise = new Promise(function () { });
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A%2F%2F192.168.1.1%3A5060')->willReturn($promise);
+
+        $server = new HttpProxyServer($loop, $socket, $connector);
+
+        $request = new ServerRequest('CONNECT', 'http://example.com', array(), null, '1.1', array('REMOTE_ADDR' => '192.168.1.1', 'REMOTE_PORT' => 5060));
+        $request = $request->withRequestTarget('example.com:80');
+
+        $response = $server->handleRequest($request);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $response);
+    }
+
+    public function testRequestAbsoluteCallsConnector()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $socket = $this->getMockBuilder('React\Socket\ServerInterface')->getMock();
+
+        $promise = new Promise(function () { });
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A%2F%2F192.168.1.1%3A5060')->willReturn($promise);
+
+        $server = new HttpProxyServer($loop, $socket, $connector);
+
+        $request = new ServerRequest('GET', 'http://example.com/path', array(), null, '1.1', array('REMOTE_ADDR' => '192.168.1.1', 'REMOTE_PORT' => 5060));
+        $request = $request->withRequestTarget('http://example.com/path');
+
+        $response = $server->handleRequest($request);
+
+        $this->assertInstanceOf('React\Promise\PromiseInterface', $response);
     }
 
     public function testPlainRequestForwardsWithExplicitHeadersAsGiven()

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use LeProxy\LeProxy\Logger;
+
+class LoggerTest extends PHPUnit_Framework_TestCase
+{
+    public function testLogFailConnectionWithoutSourcePrintsErrorWithoutSource()
+    {
+        $this->expectOutputRegex('/\?\?\? failed to connect to example\.com:80 \(error\)\s+$/');
+
+        $logger = new Logger();
+        $logger->logFailConnection(null, 'example.com:80', 'error');
+    }
+
+    public function testLogFailConnectionWithSourcePrintsErrorWithSource()
+    {
+        $this->expectOutputRegex('/http:\/\/user@host failed to connect to example\.com:80 \(error\)\s+$/');
+
+        $logger = new Logger();
+        $logger->logFailConnection('http://user:pass@host:8080', 'example.com:80', 'error');
+    }
+
+    public function testLogConnectionWithoutSourcePrintsSuccessWithoutSource()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to example\.com:80\s+$/');
+
+        $logger = new Logger();
+        $logger->logConnection(null, 'example.com:80', null);
+    }
+
+    public function testConnectSuccessWithSourcePrintsSuccessWithSource()
+    {
+        $this->expectOutputRegex('/http:\/\/user@host connected to example\.com:80\s+$/');
+
+        $logger = new Logger();
+        $logger->logConnection('http://user:pass@host:8080', 'example.com:80', null);
+    }
+
+    public function testLogConnectionWithoutRemoteIpPrintsSuccessWithDestinationAndIp()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to example\.com:80 \(1\.2\.3\.4:5060\)\s+$/');
+
+        $logger = new Logger();
+        $logger->logConnection(null, 'example.com:80', '1.2.3.4:5060');
+    }
+
+    public function testConnectSuccessWithoutSameRemoteIpPrintsSuccessWithDestinationWithoutIp()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to 1\.2\.3\.4:5060\s+$/');
+
+        $logger = new Logger();
+        $logger->logConnection(null, '1.2.3.4:5060', '1.2.3.4:5060');
+    }
+}

--- a/tests/LoggingConnectorTest.php
+++ b/tests/LoggingConnectorTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use LeProxy\LeProxy\LoggingConnector;
+use React\Promise;
+
+class LoggingConnectorTest extends PHPUnit_Framework_TestCase
+{
+    public function testConnectPendingDoesNotPrintAnything()
+    {
+        $this->expectOutputString('');
+
+        $promise = new Promise\Promise(function () { });
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80');
+    }
+
+    public function testConnectErrorWithoutSourcePrintsErrorWithoutSource()
+    {
+        $this->expectOutputRegex('/\?\?\? failed to connect to example\.com:80 \(error\)\s+$/');
+
+        $promise = Promise\reject(new RuntimeException('error'));
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80');
+    }
+
+    public function testConnectErrorWithSourcePrintsErrorWithSource()
+    {
+        $this->expectOutputRegex('/http:\/\/user@host failed to connect to example\.com:80 \(error\)\s+$/');
+
+        $promise = Promise\reject(new RuntimeException('error'));
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A//user:pass@host:8080')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80?source=http%3A//user:pass@host:8080');
+    }
+
+    public function testConnectSuccessWithoutSourcePrintsSuccessWithoutSource()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to example\.com:80\s+$/');
+
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $promise = Promise\resolve($connection);
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80');
+    }
+
+    public function testConnectSuccessWithSourcePrintsSuccessWithSource()
+    {
+        $this->expectOutputRegex('/http:\/\/user@host connected to example\.com:80\s+$/');
+
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+
+        $promise = Promise\resolve($connection);
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A//user:pass@host:8080')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80?source=http%3A//user:pass@host:8080');
+    }
+
+    public function testConnectSuccessWithoutRemoteIpPrintsSuccessWithDestinationAndIp()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to example\.com:80 \(1\.2\.3\.4:5060\)\s+$/');
+
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection->expects($this->once())->method('getRemoteAddress')->willReturn('1.2.3.4:5060');
+
+        $promise = Promise\resolve($connection);
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('example.com:80');
+    }
+
+    public function testConnectSuccessWithoutSameRemoteIpPrintsSuccessWithDestinationWithoutIp()
+    {
+        $this->expectOutputRegex('/\?\?\? connected to 1\.2\.3\.4:5060\s+$/');
+
+        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
+        $connection->expects($this->once())->method('getRemoteAddress')->willReturn('1.2.3.4:5060');
+
+        $promise = Promise\resolve($connection);
+
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('1.2.3.4:5060')->willReturn($promise);
+
+        $connector = new LoggingConnector($connector);
+
+        $connector->connect('1.2.3.4:5060');
+    }
+}

--- a/tests/LoggingConnectorTest.php
+++ b/tests/LoggingConnectorTest.php
@@ -7,50 +7,49 @@ class LoggingConnectorTest extends PHPUnit_Framework_TestCase
 {
     public function testConnectPendingDoesNotPrintAnything()
     {
-        $this->expectOutputString('');
-
         $promise = new Promise\Promise(function () { });
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->never())->method('logConnection');
+        $logger->expects($this->never())->method('logFailConnection');
+        $connector = new LoggingConnector($connector, $logger);
 
         $connector->connect('example.com:80');
     }
 
     public function testConnectErrorWithoutSourcePrintsErrorWithoutSource()
     {
-        $this->expectOutputRegex('/\?\?\? failed to connect to example\.com:80 \(error\)\s+$/');
-
         $promise = Promise\reject(new RuntimeException('error'));
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->once())->method('logFailConnection')->with(null, 'example.com:80', 'error');
+        $connector = new LoggingConnector($connector, $logger);
 
         $connector->connect('example.com:80');
     }
 
     public function testConnectErrorWithSourcePrintsErrorWithSource()
     {
-        $this->expectOutputRegex('/http:\/\/user@host failed to connect to example\.com:80 \(error\)\s+$/');
-
         $promise = Promise\reject(new RuntimeException('error'));
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A//user:pass@host:8080')->willReturn($promise);
+        $connector->expects($this->once())->method('connect')->with($this->stringStartsWith('example.com:80?source='))->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->once())->method('logFailConnection')->with('http://user:pass@host:8080', $this->stringStartsWith('example.com:80?source='), 'error');
+        $connector = new LoggingConnector($connector, $logger);
 
-        $connector->connect('example.com:80?source=http%3A//user:pass@host:8080');
+        $connector->connect('example.com:80?source=' . rawurlencode('http://user:pass@host:8080'));
     }
 
     public function testConnectSuccessWithoutSourcePrintsSuccessWithoutSource()
     {
-        $this->expectOutputRegex('/\?\?\? connected to example\.com:80\s+$/');
-
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $promise = Promise\resolve($connection);
@@ -58,31 +57,31 @@ class LoggingConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->once())->method('logConnection')->with(null, 'example.com:80', null);
+        $connector = new LoggingConnector($connector, $logger);
 
         $connector->connect('example.com:80');
     }
 
     public function testConnectSuccessWithSourcePrintsSuccessWithSource()
     {
-        $this->expectOutputRegex('/http:\/\/user@host connected to example\.com:80\s+$/');
-
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
 
         $promise = Promise\resolve($connection);
 
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A//user:pass@host:8080')->willReturn($promise);
+        $connector->expects($this->once())->method('connect')->with($this->stringStartsWith('example.com:80?source='))->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->once())->method('logConnection')->with('http://user:pass@host:8080', $this->stringStartsWith('example.com:80?source='), null);
+        $connector = new LoggingConnector($connector, $logger);
 
-        $connector->connect('example.com:80?source=http%3A//user:pass@host:8080');
+        $connector->connect('example.com:80?source=' . rawurlencode('http://user:pass@host:8080'));
     }
 
     public function testConnectSuccessWithoutRemoteIpPrintsSuccessWithDestinationAndIp()
     {
-        $this->expectOutputRegex('/\?\?\? connected to example\.com:80 \(1\.2\.3\.4:5060\)\s+$/');
-
         $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
         $connection->expects($this->once())->method('getRemoteAddress')->willReturn('1.2.3.4:5060');
 
@@ -91,25 +90,10 @@ class LoggingConnectorTest extends PHPUnit_Framework_TestCase
         $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
         $connector->expects($this->once())->method('connect')->with('example.com:80')->willReturn($promise);
 
-        $connector = new LoggingConnector($connector);
+        $logger = $this->getMockBuilder('LeProxy\LeProxy\Logger')->getMock();
+        $logger->expects($this->once())->method('logConnection')->with(null, 'example.com:80', '1.2.3.4:5060');
+        $connector = new LoggingConnector($connector, $logger);
 
         $connector->connect('example.com:80');
-    }
-
-    public function testConnectSuccessWithoutSameRemoteIpPrintsSuccessWithDestinationWithoutIp()
-    {
-        $this->expectOutputRegex('/\?\?\? connected to 1\.2\.3\.4:5060\s+$/');
-
-        $connection = $this->getMockBuilder('React\Socket\ConnectionInterface')->getMock();
-        $connection->expects($this->once())->method('getRemoteAddress')->willReturn('1.2.3.4:5060');
-
-        $promise = Promise\resolve($connection);
-
-        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
-        $connector->expects($this->once())->method('connect')->with('1.2.3.4:5060')->willReturn($promise);
-
-        $connector = new LoggingConnector($connector);
-
-        $connector->connect('1.2.3.4:5060');
     }
 }

--- a/tests/SourceConnectorTest.php
+++ b/tests/SourceConnectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use LeProxy\LeProxy\SourceConnector;
+
+class SourceConnectorTest extends PHPUnit_Framework_TestCase
+{
+    public function testConnnectAppendsSource()
+    {
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80?source=http%3A%2F%2Fuser%3Apass%401.2.3.4%3A5060');
+
+        $connector = new SourceConnector($connector, 'http://user:pass@1.2.3.4:5060');
+
+        $connector->connect('example.com:80');
+    }
+
+    public function testConnnectAppendsSourceBehindExistingQuery()
+    {
+        $connector = $this->getMockBuilder('React\Socket\ConnectorInterface')->getMock();
+        $connector->expects($this->once())->method('connect')->with('example.com:80/?host=test&source=http%3A%2F%2Fuser%3Apass%401.2.3.4%3A5060');
+
+        $connector = new SourceConnector($connector, 'http://user:pass@1.2.3.4:5060');
+
+        $connector->connect('example.com:80/?host=test');
+    }
+}

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -17,7 +17,7 @@ out=$(php $bin --proxy= 2>&1 || true) && echo "$out" | grep -q "see --help" && e
 out=$(php $bin --proxy=tcp://host/ 2>&1 || true) && echo "$out" | grep -q "see --help" && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
 killall php 2>&- 1>&- || true
-php $bin 127.0.0.1:8180 &
+php $bin 127.0.0.1:8180 --no-log &
 sleep 2
 
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
@@ -36,7 +36,7 @@ out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8180 http://test.
 
 # restart LeProxy on IPv6 address
 killall php 2>&- 1>&- || true
-php $bin [::]:8180 &
+php $bin [::]:8180 --no-log &
 sleep 2
 
 out=$(curl -v --head --silent --fail --proxy http://[::1]:8180 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
@@ -48,7 +48,7 @@ out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8180 http://react
 
 # restart LeProxy with authentication required
 killall php 2>&- 1>&- || true
-php $bin user:pass@127.0.0.1:8180 &
+php $bin user:pass@127.0.0.1:8180 --no-log &
 sleep 2
 
 # authentication should work
@@ -60,7 +60,7 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://reactp
 out=$(curl -v --head --silent --fail --proxy socks5://127.0.0.1:8180 http://reactphp.org 2>&1) && echo "FAIL: $out" && exit 1 || echo OK
 
 # start another LeProxy instance for HTTP proxy chaining / nesting
-php $bin 127.0.0.1:8181 --proxy=http://user:pass@127.0.0.1:8180 &
+php $bin 127.0.0.1:8181 --proxy=http://user:pass@127.0.0.1:8180 --no-log &
 sleep 2
 
 # client does not need authentication because first chain passes to next via HTTP
@@ -68,7 +68,7 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8181 http://reactp
 out=$(curl -v --head --silent --fail --proxy socks://127.0.0.1:8181 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
 # start another LeProxy instance for SOCKS proxy chaining / nesting
-php $bin 127.0.0.1:8182 --proxy=socks://user:pass@127.0.0.1:8180 &
+php $bin 127.0.0.1:8182 --proxy=socks://user:pass@127.0.0.1:8180 --no-log &
 sleep 2
 
 # client does not need authentication because first chain passes to next via SOCKS


### PR DESCRIPTION
This PR implements logging for all connection attempts.

```
$ php leproxy.php
LeProxy HTTP/SOCKS proxy now listening on http://0.0.0.0:8080 (protected mode, local access only)
2017-08-01 14:33:48.787 http://127.0.0.1 connected to leproxy.org:443 (88.79.198.180:443)
2017-08-01 14:33:51.077 http://127.0.0.1 connected to leproxy.org:443 (88.79.198.180:443)
2017-08-01 14:33:57.503 http://127.0.0.1 failed to connect to leproxy.invalid:443 (DNS Request did not return valid answer.)
```

A follow-up PR will eventually add logging for failed authentication attempts etc.

Builds on top of #14 by @legionth, thanks!