### PR TITLE
Update HTTP dependencies and reject chunked requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "clue/connection-manager-extra": "^1.1",
         "clue/http-proxy-react": "^1.2",
         "clue/socks-react": "^0.8.5",
-        "react/http": "^0.8.1",
-        "react/http-client": "^0.5.8",
+        "react/http": "^0.8.3",
+        "react/http-client": "^0.5.9",
         "react/socket": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a66642cf7690d5e7fd33d41cde73b57f",
+    "content-hash": "25db1089664e456dcbe456bdc1749db4",
     "packages": [
         {
             "name": "clue/commander",
@@ -448,16 +448,16 @@
         },
         {
             "name": "react/http",
-            "version": "v0.8.1",
+            "version": "v0.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http.git",
-                "reference": "92deba861d5a1320584450cfa61622a2969b00ef"
+                "reference": "f8bcdab2dc0ecd94f35ff9657a263028b96f0c46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http/zipball/92deba861d5a1320584450cfa61622a2969b00ef",
-                "reference": "92deba861d5a1320584450cfa61622a2969b00ef",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/f8bcdab2dc0ecd94f35ff9657a263028b96f0c46",
+                "reference": "f8bcdab2dc0ecd94f35ff9657a263028b96f0c46",
                 "shasum": ""
             },
             "require": {
@@ -492,20 +492,20 @@
                 "server",
                 "streaming"
             ],
-            "time": "2018-01-05T15:30:50+00:00"
+            "time": "2018-04-11T15:03:27+00:00"
         },
         {
             "name": "react/http-client",
-            "version": "v0.5.8",
+            "version": "v0.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/http-client.git",
-                "reference": "7dd490916b07e7402b7143e1ad6803fdb50c5e98"
+                "reference": "f8e81a022b61938e0b37c94c6351fc170b7d87f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http-client/zipball/7dd490916b07e7402b7143e1ad6803fdb50c5e98",
-                "reference": "7dd490916b07e7402b7143e1ad6803fdb50c5e98",
+                "url": "https://api.github.com/repos/reactphp/http-client/zipball/f8e81a022b61938e0b37c94c6351fc170b7d87f6",
+                "reference": "f8e81a022b61938e0b37c94c6351fc170b7d87f6",
                 "shasum": ""
             },
             "require": {
@@ -518,7 +518,9 @@
                 "ringcentral/psr7": "^1.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+                "clue/block-react": "^1.2",
+                "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35",
+                "react/promise-stream": "^1.1"
             },
             "type": "library",
             "autoload": {
@@ -534,7 +536,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2018-02-09T08:42:44+00:00"
+            "time": "2018-04-10T11:38:54+00:00"
         },
         {
             "name": "react/promise",

--- a/src/HttpProxyServer.php
+++ b/src/HttpProxyServer.php
@@ -67,6 +67,17 @@ class HttpProxyServer
             $request = $request->withAttribute('source', 'http://' . $params['REMOTE_ADDR'] . ':' . $params['REMOTE_PORT']);
         }
 
+        // reject incoming request with "Transfer-Encoding: chunked"
+        if ($request->hasHeader('Transfer-Encoding')) {
+            return new Response(
+                411,
+                array(
+                    'Content-Type' => 'text/plain',
+                ) + $this->headers,
+                'LeProxy HTTP/SOCKS proxy does not allow buffering chunked requests'
+            );
+        }
+
         // direct (origin / non-proxy) requests start with a slash
         $direct = substr($request->getRequestTarget(), 0, 1) === '/';
 


### PR DESCRIPTION
Improve support for legacy HTTP servers, improve close detection and properly reject plain HTTP requests using `Transfer-Encoding: chunked`. The latter only affects rare incoming chunked requests over plaintext HTTP, it does not affect common chunked response messages or requests sent over HTTP CONNECT or SOCKS. Handling these rare requests would either involve buffering the incoming request message or re-encoding on the fly once https://github.com/reactphp/http-client/issues/38 is in.

Builds on top of #49
Refs https://github.com/reactphp/http/pull/316, https://github.com/reactphp/http/pull/318 and https://github.com/reactphp/http-client/pull/130