### PR TITLE
Support listening on Unix domain socket (UDS) paths and proxy forwarding/chaining via Unix domain socket (UDS) paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ $ php leproxy.php --proxy=socks://user:pass@127.0.0.1:8080
 ```
 
 > The upstream proxy server URI MUST contain a hostname or IP and SHOULD include
-  a port unless the proxy happens to use default port `8080`.
+  a port unless the proxy happens to use default port `8080` (or you can use a
+  Unix domain socket path).
   If no scheme is given, the `http://` scheme will be assumed.
   If no port is given, port `8080` will be assumed regardless of scheme.
   The `http://` and `socks[5]://` schemes support optional username/password

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ $ php leproxy.php 127.0.0.1:8080
 ```
 
 > The listening address MUST be in the form `ip:port` or just `ip` or `:port`,
-  with the above defaults being applied.
+  with the above defaults being applied (or you can use a Unix domain socket
+  path).
 
 Note that LeProxy runs in protected mode by default, so that it only forwards
 requests from the local host and can not be abused as an open proxy.

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "php": ">=5.4",
         "clue/commander": "^1.3",
         "clue/connection-manager-extra": "^1.1",
-        "clue/http-proxy-react": "^1.2",
-        "clue/socks-react": "^0.8.5",
+        "clue/http-proxy-react": "^1.3",
+        "clue/socks-react": "^0.8.7",
         "react/http": "^0.8.3",
         "react/http-client": "^0.5.9",
         "react/socket": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "25db1089664e456dcbe456bdc1749db4",
+    "content-hash": "a149a1c8ebe60763b53540b8d42f6418",
     "packages": [
         {
             "name": "clue/commander",
@@ -117,22 +117,22 @@
         },
         {
             "name": "clue/http-proxy-react",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-http-proxy-react.git",
-                "reference": "06bc84cda43c724edc5b5a19f61452e8094ba99d"
+                "reference": "eeff725640ed53386a6adb05ffdbfc2837404fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-http-proxy-react/zipball/06bc84cda43c724edc5b5a19f61452e8094ba99d",
-                "reference": "06bc84cda43c724edc5b5a19f61452e8094ba99d",
+                "url": "https://api.github.com/repos/clue/php-http-proxy-react/zipball/eeff725640ed53386a6adb05ffdbfc2837404fdf",
+                "reference": "eeff725640ed53386a6adb05ffdbfc2837404fdf",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3",
                 "react/promise": " ^2.1 || ^1.2.1",
-                "react/socket": "^1.0 || ^0.8 || ^0.7.1",
+                "react/socket": "^1.0 || ^0.8.4",
                 "ringcentral/psr7": "^1.2"
             },
             "require-dev": {
@@ -156,7 +156,7 @@
                     "email": "christian@lueck.tv"
                 }
             ],
-            "description": "Async HTTP CONNECT proxy connector, use any TCP/IP protocol through an HTTP proxy server, built on top of ReactPHP",
+            "description": "Async HTTP proxy connector, use any TCP/IP-based protocol through an HTTP CONNECT proxy server, built on top of ReactPHP",
             "homepage": "https://github.com/clue/php-http-proxy-react",
             "keywords": [
                 "async",
@@ -165,32 +165,32 @@
                 "proxy",
                 "reactphp"
             ],
-            "time": "2017-08-30T06:47:01+00:00"
+            "time": "2018-02-13T16:31:32+00:00"
         },
         {
             "name": "clue/socks-react",
-            "version": "v0.8.5",
+            "version": "v0.8.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/clue/php-socks-react.git",
-                "reference": "00f7f16c2aceedd144b08a19a1414564c8e99d2d"
+                "reference": "0fcd6f2f506918ff003f1b995c6e78443f26e8ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-socks-react/zipball/00f7f16c2aceedd144b08a19a1414564c8e99d2d",
-                "reference": "00f7f16c2aceedd144b08a19a1414564c8e99d2d",
+                "url": "https://api.github.com/repos/clue/php-socks-react/zipball/0fcd6f2f506918ff003f1b995c6e78443f26e8ea",
+                "reference": "0fcd6f2f506918ff003f1b995c6e78443f26e8ea",
                 "shasum": ""
             },
             "require": {
-                "evenement/evenement": "~1.0|~2.0",
+                "evenement/evenement": "~3.0|~1.0|~2.0",
                 "php": ">=5.3",
                 "react/promise": "^2.1 || ^1.2",
-                "react/socket": "^1.0 || ^0.8 || ^0.7"
+                "react/socket": "^1.0 || ^0.8.6"
             },
             "require-dev": {
                 "clue/block-react": "^1.1",
                 "clue/connection-manager-extra": "^1.0 || ^0.7",
-                "phpunit/phpunit": "^5.0 || ^4.8",
+                "phpunit/phpunit": "^6.0 || ^5.7 || ^4.8.35",
                 "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3"
             },
             "type": "library",
@@ -220,7 +220,7 @@
                 "socks server",
                 "tcp tunnel"
             ],
-            "time": "2017-09-01T10:37:29+00:00"
+            "time": "2017-12-17T14:47:58+00:00"
         },
         {
             "name": "evenement/evenement",

--- a/leproxy.php
+++ b/leproxy.php
@@ -94,8 +94,8 @@ Arguments:
         forwarded to (proxy chaining).
         Any number of upstream proxies can be given.
         Each address consists of full URI which may contain a scheme, username
-        and password, host and port. Default scheme is `http://`, default port
-        is `8080` for all schemes.
+        and password, host and port (or Unix domain socket path). Default scheme
+        is `http://`, default port is `8080` for all schemes.
 
     --no-log
         By default, LeProxy logs all connection attempts to STDOUT for

--- a/leproxy.php
+++ b/leproxy.php
@@ -61,7 +61,7 @@ Arguments:
     <listenAddress>
         The socket address to listen on.
         The address consists of a full URI which may contain a username and
-        password, host and port.
+        password, host and port (or Unix domain socket path).
         By default, LeProxy will listen on the public address 0.0.0.0:8080.
         LeProxy will report an error if it fails to listen on the given address,
         you may try another address or use port `0` to pick a random free port.
@@ -190,7 +190,7 @@ try {
     exit(71);
 }
 
-$addr = str_replace('tcp://', 'http://', $socket->getAddress());
+$addr = str_replace(array('tcp://', 'unix://'), array('http://', 'http+unix://'), $socket->getAddress());
 echo 'LeProxy HTTP/SOCKS proxy now listening on ' . $addr . ' (';
 if (strpos($args['listen'], '@') !== false) {
     echo 'authentication required';

--- a/src/ConnectorFactory.php
+++ b/src/ConnectorFactory.php
@@ -72,6 +72,11 @@ class ConnectorFactory
      */
     public static function coerceListenUri($uri)
     {
+        // match Unix domain sockets (UDS) paths like "[user:pass@]/path"
+        if (preg_match('/^(?:[^@]*@)?.?.?\/.*$/', $uri)) {
+            return $uri;
+        }
+
         // apply default host if omitted for `:port` or `user@:port`
         $original = $uri;
         $uri = preg_replace('/(^|@)(:\d+)?$/', '${1}0.0.0.0${2}', $uri);

--- a/tests/ConnectorFactoryTest.php
+++ b/tests/ConnectorFactoryTest.php
@@ -13,6 +13,17 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
             'socks://user:pass@host' => 'socks5://user:pass@host:8080',
             'user@host' => 'http://user:@host:8080',
             'socks4a://10.20.30.40:5060' => 'socks4a://10.20.30.40:5060',
+
+            './proxy.sock' => 'http+unix://./proxy.sock',
+            '/tmp/proxy.sock' => 'http+unix:///tmp/proxy.sock',
+            'user:pass@./proxy.sock' => 'http+unix://user:pass@./proxy.sock',
+            'http+unix://./proxy.sock' => 'http+unix://./proxy.sock',
+            'http+unix:///tmp/proxy.sock' => 'http+unix:///tmp/proxy.sock',
+            'http+unix://user:pass@./proxy.sock' => 'http+unix://user:pass@./proxy.sock',
+            'http+unix://user@./proxy.sock' => 'http+unix://user@./proxy.sock',
+            'socks+unix://./proxy.sock' => 'socks+unix://./proxy.sock',
+            'socks+unix://user:pass@./proxy.sock' => 'socks5+unix://user:pass@./proxy.sock',
+            'socks5+unix://user:pass@./proxy.sock' => 'socks5+unix://user:pass@./proxy.sock',
         );
 
         foreach ($uris as $in => $out) {
@@ -30,12 +41,15 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
             'excessive path' => 'host/root',
             'excessive query' => 'host?query',
             'excessive fragment' => 'host#fragment',
+
+            'excessive dots' => '.../server.sock',
+            'auth for invalid socks4+unix' => 'socks4+unix://user:pass@./proxy.sock'
         );
 
         foreach ($uris as $uri) {
             try {
                 ConnectorFactory::coerceProxyUri($uri);
-                $this->fail();
+                $this->fail($uri);
             } catch (InvalidArgumentException $e) {
                 $this->assertTrue(true);
             }

--- a/tests/ConnectorFactoryTest.php
+++ b/tests/ConnectorFactoryTest.php
@@ -57,7 +57,13 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
             '12:34@:45' => '12:34@0.0.0.0:45',
             'user:pass@' => 'user:pass@0.0.0.0:8080',
             '[::1]' => '[::1]:8080',
-            'user:pass@[::1]' => 'user:pass@[::1]:8080'
+            'user:pass@[::1]' => 'user:pass@[::1]:8080',
+
+            './proxy.sock' => './proxy.sock',
+            '../proxy.sock' => '../proxy.sock',
+            '/tmp/proxy.sock' => '/tmp/proxy.sock',
+            'user:pass@./proxy.sock' => 'user:pass@./proxy.sock',
+            'user:pass@/tmp/proxy.sock' => 'user:pass@/tmp/proxy.sock',
         );
 
         foreach ($uris as $in => $out) {
@@ -75,6 +81,9 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
             'excessive path' => '127.0.0.1:8080/root',
             'excessive query' => '127.0.0.1:8080?query',
             'excessive fragment' => '127.0.0.1:8080#fragment',
+
+            'excessive dots' => '.../proxy.sock',
+            'path looks like hostname' => 'proxy.sock',
         );
 
         foreach ($uris as $uri) {

--- a/tests/LeProxyServerTest.php
+++ b/tests/LeProxyServerTest.php
@@ -12,7 +12,7 @@ class LeProxyServerTest extends PHPUnit_Framework_TestCase
 
         $proxy = new LeProxyServer($loop);
 
-        $proxy->listen('///', false);
+        $proxy->listen('@@@', false);
     }
 
     public function testProxyDoesNotBlockTheLoopIfSocketIsClosed()
@@ -41,5 +41,29 @@ class LeProxyServerTest extends PHPUnit_Framework_TestCase
         $this->assertStringEndsNotWith(':0', $addr);
 
         $socket->close();
+    }
+
+    public function testProxyDoesCreateSocketForUnixDomainSocketPath()
+    {
+        if (!in_array('unix', stream_get_transports())) {
+            $this->markTestSkipped('System does not support unix:// scheme');
+        }
+
+        $loop = Factory::create();
+
+        $proxy = new LeProxyServer($loop);
+
+        $path = tempnam(sys_get_temp_dir(), 'sock');
+        unlink($path);
+
+        $socket = $proxy->listen('user:pass@' . $path, false);
+
+        $addr = $socket->getAddress();
+
+        $this->assertEquals('unix://' . $path, $addr);
+
+        $socket->close();
+
+        unlink($path);
     }
 }

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -92,11 +92,14 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://googl
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://maps.google.com 2>&1) && echo "FAIL: $out" && exit 1 || (echo "$out" | grep -q "403 Forbidden" && echo OK) || (echo "FAIL: $out" && exit 1) || exit 1
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
-# restart LeProxy on Unix domain socket path
+# restart LeProxy on Unix domain socket path and another LeProxy instance for chaining
 killall php 2>&- 1>&- || true
 php $bin ./leproxy.tmp.socket --no-log &
 pid=$!
-sleep 1
+php $bin :8180 --proxy ./leproxy.tmp.socket --no-log &
+sleep 2
+
+out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 http://reactphp.org 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 kill $pid && rm leproxy.tmp.socket && echo . || (echo "FAIL" && exit 1) || exit 1
 
 # restart LeProxy with authentication required

--- a/tests/acceptance.sh
+++ b/tests/acceptance.sh
@@ -92,6 +92,13 @@ out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://googl
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://maps.google.com 2>&1) && echo "FAIL: $out" && exit 1 || (echo "$out" | grep -q "403 Forbidden" && echo OK) || (echo "FAIL: $out" && exit 1) || exit 1
 out=$(curl -v --head --silent --fail --proxy http://127.0.0.1:8180 https://google.de 2>&1) && echo OK || (echo "FAIL: $out" && exit 1) || exit 1
 
+# restart LeProxy on Unix domain socket path
+killall php 2>&- 1>&- || true
+php $bin ./leproxy.tmp.socket --no-log &
+pid=$!
+sleep 1
+kill $pid && rm leproxy.tmp.socket && echo . || (echo "FAIL" && exit 1) || exit 1
+
 # restart LeProxy with authentication required
 killall php 2>&- 1>&- || true
 php $bin user:pass@127.0.0.1:8180 --no-log &


### PR DESCRIPTION
LeProxy now supports listening on Unix domain socket (UDS) paths and proxy forwarding/chaining via Unix domain socket (UDS) paths, both of which are considered advanced usage:

```bash
$ php leproxy.php ./proxy.socket

$ php.leproxy.php :8080 --proxy http+unix://./proxy.socket
```

Builds on top of #50 (which refs https://github.com/reactphp/http/pull/307)
Refs https://github.com/clue/reactphp-socks/pull/69 and https://github.com/clue/reactphp-http-proxy/pull/20