### PR TITLE
Add support for HTTPS proxy

### DIFF
--- a/src/ConnectorFactory.php
+++ b/src/ConnectorFactory.php
@@ -120,8 +120,8 @@ class ConnectorFactory
             $uri = (string)substr($uri, 0, -2);
         }
 
-        $parts = parse_url('http://' . $uri);
-        if (!$parts || !isset($parts['scheme'], $parts['host']) || isset($parts['path']) || isset($parts['query']) || isset($parts['fragment'])) {
+        $parts = parse_url((stripos($uri, 'https://') === 0 ? '' : 'http://') . $uri);
+        if (!$parts || !isset($parts['scheme'], $parts['host']) || isset($parts['path']) || isset($parts['fragment'])) {
             throw new \InvalidArgumentException('Listening URI "' . $original . '" can not be parsed as a valid URI');
         }
 

--- a/tests/ConnectorFactoryTest.php
+++ b/tests/ConnectorFactoryTest.php
@@ -93,7 +93,6 @@ class ConnectorFactoryTest extends PHPUnit_Framework_TestCase
             'wildcard hostname' => '*:8080',
             'excessive scheme' => 'http://127.0.0.1:8080',
             'excessive path' => '127.0.0.1:8080/root',
-            'excessive query' => '127.0.0.1:8080?query',
             'excessive fragment' => '127.0.0.1:8080#fragment',
 
             'excessive dots' => '.../proxy.sock',


### PR DESCRIPTION
Can be used with `php leproxy.php 'https://127.0.0.1:5512?local_cert=/home/kelunik/GitHub/amphp/http-server/tools/tls/localhost.pem'`

See https://github.com/amphp/http-client/blob/58c0c19767cb6ade95f29983f0cb540a83dde752/examples/basic/8-proxy.php for a client implementation.